### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve DocsApp 
+
+---
+
+## Bug report
+### Summary
+Quick summary what's this issue about.
+
+### Step to reproduce
+How to reproduce the issue, including custom code if needed.
+
+### Observed behavior
+How it behaved after following steps above.
+
+### Expected behavior
+How it should behave after following steps above.
+
+### Environment
+Apache/nginx and version, browser, etc. Any relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for DocsApp
+
+---
+
+## Feature request
+### Summary
+Quick summary what's this feature request about.
+
+### Why is it needed?
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Suggested solution(s)
+A clear and concise description of what you want to happen.
+
+### Related issue(s)/PR(s)
+Let us know if this is related to any issue/pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### What does it do?
+Describe the technical changes you did.
+
+### Why is it needed?
+Describe the issue you are solving.
+
+### Related issue(s)/PR(s)
+Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)


### PR DESCRIPTION
### What does it do?
Add templates for new issues and PR's.

### Why is it needed?
It make managing issues and PR's easier by asking same basic information that helps reviewers etc.

### Related issue(s)/PR(s)
Resolves issue #20 
