### PR TITLE
Rewrite to services, simplify views

### DIFF
--- a/src/Containers/Logger.php
+++ b/src/Containers/Logger.php
@@ -7,7 +7,6 @@ use Monolog\Processor\UidProcessor;
 use Monolog\Handler\StreamHandler;
 use Slim\Container;
 
-
 class Logger
 {
     public static function load(Container $container)

--- a/src/Containers/PageNotFound.php
+++ b/src/Containers/PageNotFound.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace MODXDocs\Containers;
 
 use Slim\Container;
 
 use MODXDocs\Views\NotFound;
-
 
 class PageNotFound
 {

--- a/src/Containers/Services.php
+++ b/src/Containers/Services.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MODXDocs\Containers;
+
+use Slim\Container;
+
+use MODXDocs\Services\FilePathService;
+use MODXDocs\Services\RequestPathService;
+use MODXDocs\Services\NavigationService;
+use MODXDocs\Services\RequestAttributesService;
+use MODXDocs\Services\DocumentService;
+use MODXDocs\Services\VersionsService;
+use MODXDocs\Services\NotFoundService;
+
+class Services
+{
+    public static function load(Container $container)
+    {
+        $container[RequestAttributesService::class] = function () {
+            return new RequestAttributesService();
+        };
+
+        $container[NavigationService::class] = function (Container $container) {
+            return new NavigationService(
+                $container->get('view'),
+                $container->get('logger'),
+                $container->get('router'),
+                $container->get(RequestPathService::class),
+                $container->get(RequestAttributesService::class),
+                $container->get(FilePathService::class)
+            );
+        };
+
+        $container[RequestPathService::class] = function (Container $container) {
+            return new RequestPathService(
+                $container->get(RequestAttributesService::class)
+            );
+        };
+
+        $container[FilePathService::class] = function (Container $container) {
+            return new FilePathService(
+                $container->get(RequestPathService::class),
+                $container->get(RequestAttributesService::class)
+            );
+        };
+
+        $container[DocumentService::class] = function (Container $container) {
+            return new DocumentService(
+                $container->get(RequestPathService::class),
+                $container->get(FilePathService::class),
+                $container->get(RequestAttributesService::class)
+            );
+        };
+
+        $container[VersionsService::class] = function (Container $container) {
+            return new VersionsService(
+                $container->get('router'),
+                $container->get(FilePathService::class),
+                $container->get(RequestAttributesService::class)
+            );
+        };
+
+        $container[NotFoundService::class] = function (Container $container) {
+            return new NotFoundService(
+                $container->get(RequestAttributesService::class)
+            );
+        };
+    }
+}

--- a/src/DocsApp.php
+++ b/src/DocsApp.php
@@ -1,15 +1,17 @@
 <?php
+
 namespace MODXDocs;
 
 use Slim\App;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
 use MODXDocs\Containers\View;
 use MODXDocs\Containers\PageNotFound;
 use MODXDocs\Containers\Logger;
+use MODXDocs\Containers\Services;
 use MODXDocs\Middlewares\RequestMiddleware;
 use MODXDocs\Views\Doc;
-
 
 class DocsApp
 {
@@ -18,9 +20,8 @@ class DocsApp
 
     public function __construct(array $settings)
     {
-        session_start();
-
         $this->app = new App($settings);
+
         $this->routes();
         $this->dependencies();
         $this->middlewares();
@@ -28,8 +29,8 @@ class DocsApp
 
     private function routes()
     {
-        $this->app->get('/', Doc::class . ':home')->setName('home');
-        $this->app->get('/{version}/{language}/{path:.*}',Doc::class . ':get')->setName('documentation');
+        $this->app->get('/', Doc::class . ':get')->setName('home');
+        $this->app->get('/{version}/{language}/{path:.*}', Doc::class . ':get')->setName('documentation');
     }
 
     private function middlewares()
@@ -43,6 +44,7 @@ class DocsApp
             View::class,
             PageNotFound::class,
             Logger::class,
+            Services::class
         ];
 
         foreach ($containers as $container) {
@@ -56,7 +58,7 @@ class DocsApp
         $this->app->run();
     }
 
-    public function process(ServerRequestInterface $request, ResponseInterface $response)
+    public function process(Request $request, Response $response)
     {
         return $this->app->process($request, $response);
     }

--- a/src/Exceptions/RedirectNotFoundException.php
+++ b/src/Exceptions/RedirectNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MODXDocs\Exceptions;
+
+class RedirectNotFoundException extends \Exception
+{
+}

--- a/src/Helpers/SettingsParser.php
+++ b/src/Helpers/SettingsParser.php
@@ -3,7 +3,6 @@
 namespace MODXDocs\Helpers;
 
 use Dotenv\Dotenv;
-use Monolog\Logger;
 
 class SettingsParser
 {
@@ -14,8 +13,8 @@ class SettingsParser
     {
         $baseDir = dirname(dirname(__DIR__)) . '/';
         $dotFile = static::getDotFile($baseDir);
-        $dotenv = Dotenv::create($baseDir, $dotFile);
-        $dotenv->load();
+        $dotEnv = Dotenv::create($baseDir, $dotFile);
+        $dotEnv->load();
     }
 
     public function getSlimConfig()

--- a/src/Helpers/TocRenderer.php
+++ b/src/Helpers/TocRenderer.php
@@ -1,25 +1,28 @@
 <?php
+
 namespace MODXDocs\Helpers;
 
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
+use Knp\Menu\Renderer\ListRenderer;
 
-/**
- * Renders MenuItem tree as unordered list
- */
-class TocRenderer extends \Knp\Menu\Renderer\ListRenderer {
-    protected $prefix;
+class TocRenderer extends ListRenderer
+{
 
-    public function __construct(MatcherInterface $matcher, array $defaultOptions = array(), $prefix, $charset = null)
+    private $prefix;
+
+    public function __construct(MatcherInterface $matcher, $prefix, array $defaultOptions = [])
     {
         $this->prefix = $prefix;
-        parent::__construct($matcher, $defaultOptions, $charset);
+
+        parent::__construct($matcher, $defaultOptions, null);
     }
 
     protected function renderLink(ItemInterface $item, array $options = array())
     {
         $newUri = $this->prefix . $item->getUri();
         $item->setUri($newUri);
+
         return parent::renderLink($item, $options);
     }
 }

--- a/src/Middlewares/RequestMiddleware.php
+++ b/src/Middlewares/RequestMiddleware.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace MODXDocs\Middlewares;
 
-use Psr\Http\Message\RequestInterface as Request;
-use Psr\Http\Message\ResponseInterface as Response;
-
+use Slim\Http\Response;
+use Slim\Http\Request;
 
 class RequestMiddleware
 {
@@ -20,9 +20,8 @@ class RequestMiddleware
             if ($request->getMethod() === 'GET') {
                 return $response->withRedirect((string)$uri, 301);
             }
-            else {
-                return $next($request->withUri($uri), $response);
-            }
+
+            return $next($request->withUri($uri), $response);
         }
 
         return $next($request, $response);

--- a/src/Navigation/NavigationItem.php
+++ b/src/Navigation/NavigationItem.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace MODXDocs\Navigation;
+
+class NavigationItem
+{
+    const VERIFY = 'verify';
+    const NOT_VERIFY = 'not_verify';
+
+    const DEFAULT_LEVEL = 1;
+    const DEFAULT_DEPTH = 10;
+
+    const TOP_MENU_LEVEL = 1;
+    const TOP_MENU_DEPTH = 1;
+
+    const HOME_MENU_LEVEL = 1;
+    const HOME_MENU_DEPTH = 2;
+
+    private $currentFilePath;
+    private $basePath;
+    private $filePath;
+    private $urlPath;
+    private $level;
+    private $depth;
+
+    private $version;
+    private $language;
+    private $path;
+
+    public function __construct(
+        $currentFilePath,
+        $basePath,
+        $filePath,
+        $urlPath,
+        $level,
+        $depth,
+        $version,
+        $language,
+        $path
+    )
+    {
+        $this->currentFilePath = $currentFilePath;
+        $this->basePath = $basePath;
+        $this->filePath = $filePath;
+        $this->urlPath = $urlPath;
+        $this->level = $level;
+        $this->depth = $depth;
+
+        $this->version = $version;
+        $this->language = $language;
+        $this->path = $path;
+    }
+
+    public function getCurrentFilePath()
+    {
+        return $this->currentFilePath;
+    }
+
+    public function getBasePath()
+    {
+        return $this->basePath;
+    }
+
+    public function getFilePath()
+    {
+        return $this->filePath;
+    }
+
+    public function getUrlPath()
+    {
+        return $this->urlPath;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    public function getDepth()
+    {
+        return $this->depth;
+    }
+
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+}

--- a/src/Navigation/NavigationItem.php
+++ b/src/Navigation/NavigationItem.php
@@ -4,9 +4,6 @@ namespace MODXDocs\Navigation;
 
 class NavigationItem
 {
-    const VERIFY = 'verify';
-    const NOT_VERIFY = 'not_verify';
-
     const DEFAULT_LEVEL = 1;
     const DEFAULT_DEPTH = 10;
 

--- a/src/Navigation/NavigationItemBuilder.php
+++ b/src/Navigation/NavigationItemBuilder.php
@@ -3,18 +3,16 @@ namespace MODXDocs\Navigation;
 
 class NavigationItemBuilder
 {
-    const NOT_INITIALIZED = 'NOT_INITIALIZED';
+    private $currentFilePath = null;
+    private $basePath = null;
+    private $filePath = null;
+    private $urlPath = null;
+    private $level = null;
+    private $depth = null;
 
-    private $currentFilePath = NavigationItemBuilder::NOT_INITIALIZED;
-    private $basePath = NavigationItemBuilder::NOT_INITIALIZED;
-    private $filePath = NavigationItemBuilder::NOT_INITIALIZED;
-    private $urlPath = NavigationItemBuilder::NOT_INITIALIZED;
-    private $level = NavigationItemBuilder::NOT_INITIALIZED;
-    private $depth = NavigationItemBuilder::NOT_INITIALIZED;
-
-    private $version = NavigationItemBuilder::NOT_INITIALIZED;
-    private $language = NavigationItemBuilder::NOT_INITIALIZED;
-    private $path = NavigationItemBuilder::NOT_INITIALIZED;
+    private $version = null;
+    private $language = null;
+    private $path = null;
 
     public function __construct()
     {

--- a/src/Navigation/NavigationItemBuilder.php
+++ b/src/Navigation/NavigationItemBuilder.php
@@ -1,0 +1,114 @@
+<?php
+namespace MODXDocs\Navigation;
+
+class NavigationItemBuilder
+{
+    const NOT_INITIALIZED = 'NOT_INITIALIZED';
+
+    private $currentFilePath = NavigationItemBuilder::NOT_INITIALIZED;
+    private $basePath = NavigationItemBuilder::NOT_INITIALIZED;
+    private $filePath = NavigationItemBuilder::NOT_INITIALIZED;
+    private $urlPath = NavigationItemBuilder::NOT_INITIALIZED;
+    private $level = NavigationItemBuilder::NOT_INITIALIZED;
+    private $depth = NavigationItemBuilder::NOT_INITIALIZED;
+
+    private $version = NavigationItemBuilder::NOT_INITIALIZED;
+    private $language = NavigationItemBuilder::NOT_INITIALIZED;
+    private $path = NavigationItemBuilder::NOT_INITIALIZED;
+
+    public function __construct()
+    {
+        $this->level = NavigationItem::DEFAULT_LEVEL;
+        $this->depth = NavigationItem::DEFAULT_DEPTH;
+    }
+
+    public function forTopMenu()
+    {
+        $this->level = NavigationItem::TOP_MENU_LEVEL;
+        $this->depth = NavigationItem::TOP_MENU_DEPTH;
+        return $this;
+    }
+
+    public function withCurrentFilePath($currentFilePath)
+    {
+        $this->currentFilePath = $currentFilePath;
+        return $this;
+    }
+
+    public function withBasePath($basePath)
+    {
+        $this->basePath = $basePath;
+        return $this;
+    }
+
+    public function withFilePath($filePath)
+    {
+        $this->filePath = $filePath;
+        return $this;
+    }
+
+    public function withUrlPath($urlPath)
+    {
+        $this->urlPath = $urlPath;
+        return $this;
+    }
+
+    public function withLevel($level)
+    {
+        $this->level = $level;
+        return $this;
+    }
+
+    public function withDepth($depth)
+    {
+        $this->depth = $depth;
+        return $this;
+    }
+
+    public function withVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    public function withLanguage($language)
+    {
+        $this->language = $language;
+        return $this;
+    }
+
+    public function withPath($path)
+    {
+        $this->path = $path;
+        return $this;
+    }
+
+    public function build()
+    {
+        return new NavigationItem(
+            $this->currentFilePath,
+            $this->basePath,
+            $this->filePath,
+            $this->urlPath,
+            $this->level,
+            $this->depth,
+            $this->version,
+            $this->language,
+            $this->path
+        );
+    }
+
+    public static function copyFromItem(NavigationItem $item)
+    {
+        return (new NavigationItemBuilder())
+            ->withCurrentFilePath($item->getCurrentFilePath())
+            ->withBasePath($item->getBasePath())
+            ->withFilePath($item->getFilePath())
+            ->withUrlPath($item->getUrlPath())
+            ->withLevel($item->getLevel())
+            ->withDepth($item->getDepth())
+            ->withVersion($item->getVersion())
+            ->withLanguage($item->getLanguage())
+            ->withPath($item->getPath());
+    }
+}

--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace MODXDocs\Services;
+
+use Knp\Menu\Matcher\Matcher;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use Slim\Http\Request;
+use Spatie\YamlFrontMatter\YamlFrontMatter;
+use Spatie\YamlFrontMatter\Document;
+use TOC\MarkupFixer;
+use TOC\TocGenerator;
+use Webuni\CommonMark\TableExtension\TableExtension;
+
+use MODXDocs\Helpers\LinkRenderer;
+use MODXDocs\Helpers\TocRenderer;
+
+class DocumentService
+{
+    const TOC_TOP_LEVEL = 2;
+    const TOC_DEPTH = 6;
+
+    private $requestPathService;
+    private $filePathService;
+    private $requestAttributesService;
+
+    /** @var boolean */
+    private $loaded;
+
+    /** @var Document */
+    private $document;
+
+    /** @var string */
+    private $content;
+
+    /** @var string */
+    private $tableOfContents;
+
+    public function __construct(
+        RequestPathService $requestPathService,
+        FilePathService $filePathService,
+        RequestAttributesService $requestAttributesService
+    )
+    {
+        $this->requestPathService = $requestPathService;
+        $this->filePathService = $filePathService;
+        $this->requestAttributesService = $requestAttributesService;
+
+        $this->loaded = false;
+    }
+
+    private function initialize(Request $request)
+    {
+        $this->document = $this->getParsedDocument($request);
+        $this->content = $this->getDocumentContent($request);
+        $this->tableOfContents = $this->getDocumentTableOfContents($request);
+
+        $this->loaded = true;
+    }
+
+    public function getMeta(Request $request)
+    {
+        if (!$this->loaded) {
+            $this->initialize($request);
+        }
+
+        return $this->document->matter();
+    }
+
+    public function getContent(Request $request)
+    {
+        if (!$this->loaded) {
+            $this->initialize($request);
+        }
+
+        return $this->content;
+    }
+
+    public function getTableOfContents(Request $request)
+    {
+        if (!$this->loaded) {
+            $this->initialize($request);
+        }
+
+        return $this->tableOfContents;
+    }
+
+    private function getParsedDocument(Request $request)
+    {
+        $fileContents = file_get_contents($this->filePathService->getFilePath($request));
+
+        // Parse the front matter and make it available as meta
+        return YamlFrontMatter::parse($fileContents);
+    }
+
+    private function getDocumentContent(Request $request)
+    {
+        $body = $this->document->body();
+
+        // Grab the markdown
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new TableExtension());
+        $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link',
+            new LinkRenderer(
+                $this->requestPathService->getBaseUrlPath($request),
+                $this->requestAttributesService->getPath($request)
+            )
+        );
+
+        $markdown = new CommonMarkConverter([
+            'html_input' => 'allow',
+        ], $environment);
+
+        $content = $markdown->convertToHtml($body);
+
+        $fixer = new MarkupFixer();
+        return $fixer->fix($content);
+    }
+
+    private function getDocumentTableOfContents(Request $request)
+    {
+        $tocGenerator = new TocGenerator();
+
+        $renderer = new TocRenderer(new Matcher(),
+            $this->requestPathService->getFullUrlPath($request),
+            [
+                'currentClass' => 'active',
+                'ancestorClass' => 'active_ancestor'
+            ]
+        );
+
+        return $tocGenerator->getHtmlMenu(
+            $this->content,
+            static::TOC_TOP_LEVEL,
+            static::TOC_DEPTH,
+            $renderer
+        );
+    }
+}

--- a/src/Services/FilePathService.php
+++ b/src/Services/FilePathService.php
@@ -30,9 +30,7 @@ class FilePathService
 
     private function constructFilePath(Request $request)
     {
-        $requestPath = $this->requestPathService->getFullFilePath($request);
-
-        $basePath = getenv('DOCS_DIRECTORY') . rtrim($requestPath, '/');
+        $basePath = rtrim($this->requestPathService->getAbsoluteBaseFilePath($request), '/');
 
         $file = $basePath . '.md';
         if (file_exists($file)) {

--- a/src/Services/FilePathService.php
+++ b/src/Services/FilePathService.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MODXDocs\Services;
+
+use Slim\Http\Request;
+
+class FilePathService
+{
+    private $requestPathService;
+    private $requestAttributesService;
+
+    public function __construct(
+        RequestPathService $requestPathService,
+        RequestAttributesService $requestAttributesService
+    )
+    {
+        $this->requestPathService = $requestPathService;
+        $this->requestAttributesService = $requestAttributesService;
+    }
+
+    public function isValidRequest(Request $request)
+    {
+        return $this->getFilePath($request) !== null;
+    }
+
+    public function getFilePath(Request $request)
+    {
+        return $this->constructFilePath($request);
+    }
+
+    private function constructFilePath(Request $request)
+    {
+        $requestPath = $this->requestPathService->getFullFilePath($request);
+
+        $basePath = getenv('DOCS_DIRECTORY') . rtrim($requestPath, '/');
+
+        $file = $basePath . '.md';
+        if (file_exists($file)) {
+            return $file;
+        }
+
+        // See if we have an index file instead
+        $file = $basePath . '/index.md';
+        if (file_exists($file)) {
+            return $file;
+        }
+
+        return null;
+    }
+}

--- a/src/Services/FilePathService.php
+++ b/src/Services/FilePathService.php
@@ -30,7 +30,7 @@ class FilePathService
 
     private function constructFilePath(Request $request)
     {
-        $basePath = rtrim($this->requestPathService->getAbsoluteBaseFilePath($request), '/');
+        $basePath = rtrim($this->requestPathService->getAbsoluteFullFilePath($request), '/');
 
         $file = $basePath . '.md';
         if (file_exists($file)) {

--- a/src/Services/NavigationService.php
+++ b/src/Services/NavigationService.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace MODXDocs\Services;
+
+use Monolog\Logger;
+use Slim\Http\Request;
+use Slim\Router;
+use Slim\Views\Twig;
+use Spatie\YamlFrontMatter\YamlFrontMatter;
+
+use MODXDocs\Navigation\NavigationItem;
+use MODXDocs\Navigation\NavigationItemBuilder;
+
+class NavigationService
+{
+    private $twig;
+    private $logger;
+    private $router;
+    private $requestPathService;
+    private $requestAttributesService;
+    private $filePathService;
+
+    public function __construct(
+        Twig $twig,
+        Logger $logger,
+        Router $router,
+        RequestPathService $requestPathService,
+        RequestAttributesService $requestAttributesService,
+        FilePathService $filePathService
+    )
+    {
+        $this->twig = $twig;
+        $this->logger = $logger;
+        $this->router = $router;
+        $this->requestPathService = $requestPathService;
+        $this->requestAttributesService = $requestAttributesService;
+        $this->filePathService = $filePathService;
+    }
+
+    public function getTopNavigation(Request $request)
+    {
+        return $this->getNavigationForParent(
+            (new NavigationItemBuilder())
+                ->forTopMenu()
+                ->withCurrentFilePath($this->filePathService->getFilePath($request))
+                ->withBasePath($this->requestPathService->getAbsoluteBaseFilePath($request))
+                ->withFilePath($this->requestPathService->getAbsoluteBaseFilePath($request))
+                ->withUrlPath($this->requestPathService->getBaseUrlPath($request))
+                ->withVersion($this->requestAttributesService->getVersion($request))
+                ->withLanguage($this->requestAttributesService->getLanguage($request))
+                ->build()
+        );
+    }
+
+    public function getTopNavigationForItem(NavigationItem $navigationItem)
+    {
+        return $this->getNavigationForParent($navigationItem);
+    }
+
+    public function getNavigation(Request $request)
+    {
+        $baseNavigationItem = (new NavigationItemBuilder())
+            ->withCurrentFilePath($this->filePathService->getFilePath($request))
+            ->withVersion($this->requestAttributesService->getVersion($request))
+            ->withLanguage($this->requestAttributesService->getLanguage($request))
+            ->build();
+
+        // Make the navigation dependent on the current parent (administration, developing, xpdo, etc)
+        $docPath = array_filter(explode('/', $this->requestAttributesService->getPath($request)));
+
+        // If the docpath is empty, we are on the frontpage
+        if (count($docPath) === 0) {
+            return $this->renderNav(
+                $this->getNavigationForParent(
+                    NavigationItemBuilder::copyFromItem($baseNavigationItem)
+                        ->withBasePath($this->requestPathService->getAbsoluteBaseFilePath($request))
+                        ->withFilePath($this->requestPathService->getAbsoluteBaseFilePath($request))
+                        ->withUrlPath($this->requestPathService->getBaseUrlPath($request))
+                        ->withLevel(NavigationItem::HOME_MENU_LEVEL)
+                        ->withDepth(NavigationItem::HOME_MENU_DEPTH)
+                        ->build()
+                )
+            );
+        }
+
+        $menuFilePath = $this->requestPathService->getAbsoluteBaseFilePath($request) . $docPath[0];
+        $menuUrlPath = $this->requestPathService->getBaseUrlPath($request) . $docPath[0];
+
+        if (file_exists($menuFilePath) && is_dir($menuFilePath)) {
+            return $this->renderNav(
+                $this->getNavigationForParent(
+                    NavigationItemBuilder::copyFromItem($baseNavigationItem)
+                        ->withBasePath($this->requestPathService->getAbsoluteBaseFilePath($request))
+                        ->withFilePath($menuFilePath)
+                        ->withUrlPath($menuUrlPath)
+                        ->build()
+                )
+            );
+        }
+
+        // This should not happen
+        return null;
+    }
+
+    public function getNavParent(NavigationItem $navigationItem)
+    {
+        // Make the navigation dependent on the current parent (administration, developing, xpdo, etc)
+        $docPath = array_filter(explode('/', $navigationItem->getPath()));
+
+        // No top parent for the front page
+        if (count($docPath) === 0) {
+            return null;
+        }
+
+        $menuFilePath = $navigationItem->getFilePath() . $docPath[0];
+
+        if (file_exists($menuFilePath) && is_dir($menuFilePath)) {
+            if (file_exists($menuFilePath . '.md')) {
+                return $this->getNavItem(
+                    $navigationItem,
+                    new \SplFileInfo($menuFilePath . '.md'),
+                    $docPath[0]
+                );
+            }
+
+            return $this->getNavItem(
+                $navigationItem,
+                new \SplFileInfo($menuFilePath . '/index.md'),
+                $docPath[0]
+            );
+        }
+
+        return null;
+    }
+
+    private function getNavigationForParent(NavigationItem $navigationItem)
+    {
+        $nav = [];
+
+        try {
+            $dir = new \DirectoryIterator($navigationItem->getFilePath());
+        } catch (\Exception $e) {
+            $this->logger->addError(
+                'Exception '
+                . get_class($e)
+                . ' fetching navigation for '
+                . $navigationItem->getFilePath()
+                . ': '
+                . $e->getMessage()
+            );
+
+            return $nav;
+        }
+
+        foreach ($dir as $file) {
+            if ($file->isDot()) {
+                continue;
+            }
+
+            $filePath = $file->getPathname();
+            $filePath = strpos($filePath, '.md') !== false ? substr($filePath, 0, strpos($filePath, '.md')) : $filePath;
+
+            $relativeFilePath = str_replace($navigationItem->getBasePath(), '', $filePath);
+
+            if ($file->isFile() && $file->getExtension() === 'md') {
+                if ($file->getFilename() === 'index.md') {
+                    continue;
+                }
+
+                $current = $this->getNavItem(
+                    $navigationItem,
+                    $file,
+                    $relativeFilePath
+                );
+                $current['level'] = $navigationItem->getLevel();
+
+                if ($navigationItem->getLevel() < $navigationItem->getDepth() && is_dir($filePath . '/')) {
+                    $current['classes'] .= ' has-children';
+                    $current['children'] = $this->getNavigationForParent(
+                        NavigationItemBuilder::copyFromItem($navigationItem)
+                            ->withFilePath($filePath . '/')
+                            ->withLevel($navigationItem->getLevel() + 1)
+                            ->build()
+                    );
+                }
+                $nav[] = $current;
+            } elseif ($file->isDir()) {
+                if (file_exists($file->getPathname() . '/index.md')) {
+                    $current = $this->getNavItem(
+                        $navigationItem,
+                        new \SplFileInfo($file->getPathname() . '/index.md'),
+                        $relativeFilePath
+                    );
+                    $current['level'] = $navigationItem->getLevel();
+                    $current['classes'] .= ' has-children';
+
+                    if ($navigationItem->getLevel() < $navigationItem->getDepth()) {
+                        $current['children'] = $this->getNavigationForParent(
+                            NavigationItemBuilder::copyFromItem($navigationItem)
+                                ->withFilePath($file->getPathname())
+                                ->withLevel($navigationItem->getLevel() + 1)
+                                ->build()
+                        );
+                    }
+
+                    $nav[] = $current;
+                }
+            }
+
+        }
+
+        usort($nav, function ($item, $item2) {
+            $so1 = array_key_exists('sortorder', $item) ? (int)$item['sortorder'] : null;
+            $so2 = array_key_exists('sortorder', $item2) ? (int)$item2['sortorder'] : null;
+
+            if ($so1 && !$so2) {
+                return -1;
+            }
+
+            if (!$so1 && $so2) {
+                return 1;
+            }
+
+            if (!$so1 && !$so2) {
+                return strnatcmp($item['title'], $item2['title']);
+            }
+
+            return $so1 - $so2;
+        });
+
+        return $nav;
+    }
+
+    private function getNavItem(NavigationItem $navigationItem, \SplFileInfo $file, $relativeFilePath)
+    {
+        $fm = static::getNavFrontmatter($file);
+        $current = [
+            'title' => static::getNavTitle($file),
+            'uri' => $this->router->pathFor('documentation', [
+                'version' => $navigationItem->getVersion(),
+                'language' => $navigationItem->getLanguage(),
+                'path' => $relativeFilePath,
+            ]),
+            'classes' => 'item',
+        ];
+
+        if (array_key_exists('sortorder', $fm)) {
+            $current['sortorder'] = (int)$fm['sortorder'];
+        }
+
+        if (strpos($navigationItem->getCurrentFilePath(), $relativeFilePath) !== false) {
+            $current['classes'] .= ' active';
+        }
+
+        return $current;
+    }
+
+    private function renderNav(array $nav)
+    {
+        return $this->twig->fetch(
+            'partials/nav.twig', [
+                'children' => $nav
+            ]
+        );
+    }
+
+    private static function getNavTitle(\SplFileInfo $file)
+    {
+        $fm = static::getNavFrontmatter($file);
+        $title = array_key_exists('title', $fm) ? $fm['title'] : '';
+
+        if (empty($title)) {
+            $name = $file->getFilename();
+            $title = strpos($name, '.md') !== false ? substr($name, 0, strpos($name, '.md')) : $name;
+            $title = implode(' ', explode('-', $title));
+        }
+
+        return $title;
+    }
+
+    private static function getNavFrontmatter(\SplFileInfo $file)
+    {
+        $fileContents = $file->isFile() ? file_get_contents($file->getPathname()) : false;
+        $obj = YamlFrontMatter::parse($fileContents);
+        return $obj->matter();
+    }
+}

--- a/src/Services/NavigationService.php
+++ b/src/Services/NavigationService.php
@@ -102,8 +102,16 @@ class NavigationService
         return null;
     }
 
-    public function getNavParent(NavigationItem $navigationItem)
+    public function getNavParent(Request $request)
     {
+        $navigationItem = (new NavigationItemBuilder())
+            ->withCurrentFilePath($this->filePathService->getFilePath($request))
+            ->withFilePath($this->requestPathService->getAbsoluteBaseFilePath($request))
+            ->withPath($this->requestAttributesService->getPath($request))
+            ->withVersion($this->requestAttributesService->getVersion($request))
+            ->withLanguage($this->requestAttributesService->getLanguage($request))
+            ->build();
+
         // Make the navigation dependent on the current parent (administration, developing, xpdo, etc)
         $docPath = array_filter(explode('/', $navigationItem->getPath()));
 

--- a/src/Services/NotFoundService.php
+++ b/src/Services/NotFoundService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace MODXDocs\Services;
+
+use Slim\Http\Request;
+
+class NotFoundService
+{
+    const INVALID_VALUE = 'invalid_value';
+
+    private $requestAttributesService;
+
+    public function __construct(RequestAttributesService $requestAttributesService)
+    {
+        $this->requestAttributesService = $requestAttributesService;
+    }
+
+    public function getVersion(Request $request)
+    {
+        $version = $this->requestAttributesService->getVersion($request, static::INVALID_VALUE);
+        if ($version === static::INVALID_VALUE || !static::isValidatePath($version)) {
+            return RequestAttributesService::DEFAULT_VERSION;
+        }
+
+        return $version;
+    }
+
+    public function getVersionBranch(Request $request)
+    {
+        $version = $this->getVersion($request);
+        if ($version === RequestAttributesService::DEFAULT_VERSION) {
+            return RequestAttributesService::CURRENT_BRANCH_VERSION;
+        }
+
+        return $version;
+    }
+
+    public function getLanguage(Request $request)
+    {
+        $existingPath = $this->getVersionBranch($request);
+        $language = $this->requestAttributesService->getLanguage($request, static::INVALID_VALUE);
+        $newPath = $existingPath . '/' . $language;
+        if ($language === static::INVALID_VALUE || !static::isValidatePath($newPath)) {
+            return RequestAttributesService::DEFAULT_LANGUAGE;
+        }
+
+        return $language;
+    }
+
+    private static function isValidatePath($path)
+    {
+        return file_exists(getenv('DOCS_DIRECTORY') . $path);
+    }
+}

--- a/src/Services/RequestAttributesService.php
+++ b/src/Services/RequestAttributesService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MODXDocs\Services;
+
+use Slim\Http\Request;
+
+class RequestAttributesService
+{
+    const DEFAULT_VERSION = 'current';
+    const CURRENT_BRANCH_VERSION = '2.x';
+    const DEFAULT_LANGUAGE = 'en';
+    const DEFAULT_PATH = null;
+
+    public function getVersion(Request $request, $default = RequestAttributesService::DEFAULT_VERSION)
+    {
+        return $request->getAttribute('version', $default);
+    }
+
+    public function getVersionBranch(Request $request, $default = RequestAttributesService::DEFAULT_VERSION)
+    {
+        $version = $this->getVersion($request, $default);
+
+        return $version === static::DEFAULT_VERSION ? static::CURRENT_BRANCH_VERSION : $version;
+    }
+
+    public function getLanguage(Request $request, $default = RequestAttributesService::DEFAULT_LANGUAGE)
+    {
+        return $request->getAttribute('language', $default);
+    }
+
+    public function getPath(Request $request, $default = RequestAttributesService::DEFAULT_PATH)
+    {
+        return $request->getAttribute('path', $default);
+    }
+}

--- a/src/Services/RequestPathService.php
+++ b/src/Services/RequestPathService.php
@@ -26,16 +26,6 @@ class RequestPathService
         return $this->getBasePath($request, static::MODE_VERSION);
     }
 
-    public function getFullFilePath(Request $request)
-    {
-        return $this->getFullPath($request, static::MODE_VERSION_BRANCH);
-    }
-
-    public function getBaseFilePath(Request $request)
-    {
-        return $this->getBasePath($request, static::MODE_VERSION_BRANCH);
-    }
-
     public function getAbsoluteBaseFilePath(Request $request)
     {
         return getenv('DOCS_DIRECTORY') . $this->getBasePath($request, static::MODE_VERSION_BRANCH);

--- a/src/Services/RequestPathService.php
+++ b/src/Services/RequestPathService.php
@@ -31,6 +31,11 @@ class RequestPathService
         return getenv('DOCS_DIRECTORY') . $this->getBasePath($request, static::MODE_VERSION_BRANCH);
     }
 
+    public function getAbsoluteFullFilePath(Request $request)
+    {
+        return getenv('DOCS_DIRECTORY') . $this->getFullPath($request, static::MODE_VERSION_BRANCH);
+    }
+
     public function isValidRequest(Request $request)
     {
         return static::isValidPath($this->getAbsoluteBaseFilePath($request));

--- a/src/Services/RequestPathService.php
+++ b/src/Services/RequestPathService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace MODXDocs\Services;
+
+use Slim\Http\Request;
+
+class RequestPathService
+{
+    const MODE_VERSION_BRANCH = 'MODE_VERSION_BRANCH';
+    const MODE_VERSION = 'MODE_VERSION';
+
+    private $requestAttributesService;
+
+    public function __construct(RequestAttributesService $requestAttributesService)
+    {
+        $this->requestAttributesService = $requestAttributesService;
+    }
+
+    public function getFullUrlPath(Request $request)
+    {
+        return $this->getFullPath($request, static::MODE_VERSION);
+    }
+
+    public function getBaseUrlPath(Request $request)
+    {
+        return $this->getBasePath($request, static::MODE_VERSION);
+    }
+
+    public function getFullFilePath(Request $request)
+    {
+        return $this->getFullPath($request, static::MODE_VERSION_BRANCH);
+    }
+
+    public function getBaseFilePath(Request $request)
+    {
+        return $this->getBasePath($request, static::MODE_VERSION_BRANCH);
+    }
+
+    public function getAbsoluteBaseFilePath(Request $request)
+    {
+        return getenv('DOCS_DIRECTORY') . $this->getBasePath($request, static::MODE_VERSION_BRANCH);
+    }
+
+    public function isValidRequest(Request $request)
+    {
+        return static::isValidPath($this->getAbsoluteBaseFilePath($request));
+    }
+
+    private function getFullPath(Request $request, $mode)
+    {
+        $requestPath = $this->requestAttributesService->getPath($request);
+
+        if ($requestPath === null) {
+            return $this->getBasePath($request, $mode);
+        }
+
+        return rtrim($this->getBasePath($request, $mode), '/') . '/' . $requestPath;
+    }
+
+    private function getBasePath(Request $request, $mode)
+    {
+        if ($mode === static::MODE_VERSION_BRANCH) {
+            return $this->requestAttributesService->getVersionBranch($request)
+                . '/'
+                . $this->requestAttributesService->getLanguage($request)
+                . '/';
+        }
+
+        return $this->requestAttributesService->getVersion($request)
+            . '/'
+            . $this->requestAttributesService->getLanguage($request)
+            . '/';
+    }
+
+    private static function isValidPath($path)
+    {
+        return file_exists($path) || is_dir($path);
+    }
+}

--- a/src/Services/VersionsService.php
+++ b/src/Services/VersionsService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace MODXDocs\Services;
+
+use Slim\Http\Request;
+use Slim\Router;
+
+class VersionsService
+{
+    const VERSION_DEFAULT_PATH = 'index';
+
+    private $router;
+    private $filePathService;
+    private $requestAttributesService;
+
+    public function __construct(
+        Router $router,
+        FilePathService $filePathService,
+        RequestAttributesService $requestAttributesService
+    )
+    {
+        $this->router = $router;
+        $this->filePathService = $filePathService;
+        $this->requestAttributesService = $requestAttributesService;
+    }
+
+    public function getVersions(Request $request)
+    {
+        $dir = new \DirectoryIterator(getenv('DOCS_DIRECTORY'));
+
+        $versions = [];
+
+        foreach ($dir as $fileInfo) {
+            if (!$fileInfo->isDir() || $fileInfo->isDot()) {
+                continue;
+            }
+
+            // Do not include the current branch
+            if ($this->requestAttributesService->getVersionBranch($request) === $fileInfo->getFilename()) {
+                continue;
+            }
+
+            $file = $fileInfo->getPathname()
+                . '/'
+                . $this->requestAttributesService->getLanguage($request)
+                . '/'
+                . $this->requestAttributesService->getPath($request);
+
+            if (file_exists($file . '.md') || file_exists($file . '/index.md')) {
+                $versions[] = $this->createVersion($request, $fileInfo);
+            }
+        }
+
+        return $versions;
+    }
+
+    private function createVersion(Request $request, \DirectoryIterator $fileInfo)
+    {
+        return [
+            'title' => static::getVersionTitle($fileInfo->getFilename()),
+            'uri' => $this->router->pathFor('documentation', [
+                'version' => static::getVersionUrl($fileInfo->getFilename()),
+                'language' => $this->requestAttributesService->getLanguage($request),
+                'path' => $this->requestAttributesService->getPath($request, static::VERSION_DEFAULT_PATH),
+            ])
+        ];
+    }
+
+    private static function getVersionUrl($version)
+    {
+        // If we found another version e.g. 2.x, and 2.x is the `current` branch, use `current`
+        // instead of 2.x in the URL
+        if (RequestAttributesService::CURRENT_BRANCH_VERSION === $version) {
+            return RequestAttributesService::DEFAULT_VERSION;
+        }
+
+        return $version;
+    }
+
+    private static function getVersionTitle($fileVersion)
+    {
+        if (RequestAttributesService::CURRENT_BRANCH_VERSION === $fileVersion) {
+            return $fileVersion . ' (current)';
+        }
+
+        return $fileVersion;
+    }
+}

--- a/src/Twig/DocExtensions.php
+++ b/src/Twig/DocExtensions.php
@@ -7,7 +7,6 @@ use Twig\TwigFunction;
 use Slim\Http\Request;
 use Slim\Interfaces\RouterInterface;
 
-
 class DocExtensions extends AbstractExtension
 {
     private $router;
@@ -18,6 +17,7 @@ class DocExtensions extends AbstractExtension
         $this->router = $router;
         $this->request = $request;
     }
+
     public function getFunctions()
     {
         return [

--- a/src/Views/Base.php
+++ b/src/Views/Base.php
@@ -1,126 +1,92 @@
 <?php
+
 namespace MODXDocs\Views;
 
+use Psr\Container\ContainerInterface;
 use Monolog\Logger;
-use Slim\Container;
 use Slim\Http\Request;
 use Slim\Http\Response;
-use Slim\Router;
 use Slim\Views\Twig;
 
+use MODXDocs\Services\RequestAttributesService;
+use MODXDocs\Services\NavigationService;
 
 abstract class Base
 {
-    /** @var Logger */
-    protected $logger;
-    /** @var Router */
-    protected $router;
-    /** @var Container */
+    /** @var ContainerInterface */
     protected $container;
-    /** @var Request */
-    protected $request;
-    /** @var Response */
-    protected $response;
 
-    protected $arguments = array();
-    protected $variables = array();
+    /** @var Logger */
+    private $logger;
 
-    protected $options = array();
     /** @var Twig */
-    protected $view;
+    private $view;
 
-    public function __construct($container, array $options = array())
+    /** @var RequestAttributesService */
+    private $requestAttributeService;
+
+    /** @var NavigationService */
+    private $navigationService;
+
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-        $this->options = $options;
+
         $this->logger = $this->container->get('logger');
         $this->view = $this->container->get('view');
-        $this->router = $this->container->get('router');
+
+        $this->requestAttributeService = $this->container->get(RequestAttributesService::class);
+        $this->navigationService = $this->container->get(NavigationService::class);
     }
 
-    abstract public function get(Request $request, Response $response, array $args = array());
-
-    public function initialize(Request $request, Response $response, array $args = array())
+    protected function render(Request $request, Response $response, $template, array $data = [])
     {
-        $this->request =& $request;
-        $this->response =& $response;
-        $this->setArguments($args);
-        $this->setVariable('args', $args);
-        $this->setVariable('_env', $_ENV);
-        $this->setVariable('current_uri', $request->getUri()->getPath());
+        $initialData = [
+            'revision' => static::getRevision(),
+            'current_uri' => $request->getUri()->getPath(),
+            'version' => $this->requestAttributeService->getVersion($request),
+            'version_branch' => $this->requestAttributeService->getVersionBranch($request),
+            'language' => $this->requestAttributeService->getLanguage($request),
+            'path' => $this->requestAttributeService->getPath($request),
+            'topnav' => $this->navigationService->getTopNavigation($request),
+        ];
 
+        return $this->view->render(
+            $response,
+            $template,
+            \array_merge(
+                $initialData,
+                $data
+            )
+        );
+    }
+
+    protected function render404(Request $request, Response $response, array $data = [])
+    {
+        $initialData = [
+            'revision' => static::getRevision(),
+            'current_uri' => $request->getUri()->getPath(),
+        ];
+
+        return $this->view->render(
+            $response->withStatus(404),
+            'notfound.twig',
+            \array_merge(
+                $initialData,
+                $data
+            )
+        );
+    }
+
+    private static function getRevision()
+    {
         $revision = 'dev';
 
-        // TODO: not sure what this points towards?
         $projectDir = getenv('BASE_DIRECTORY');
-        if (file_exists($projectDir . '.revision'))  {
+        if (file_exists($projectDir . '.revision')) {
             $revision = file_get_contents($projectDir . '.revision');
         }
-        $this->setVariable('revision', $revision);
-        return true;
-    }
 
-    public function render($template, $response = null)
-    {
-        if (!$response && $this->response) {
-            $response = $this->response;
-        }
-
-        return $this->view->render($response, $template, $this->getVariables());
-    }
-
-    public function setVariable($key, $value)
-    {
-        $this->variables[$key] = $value;
-    }
-
-    public function setVariables(array $values = array(), $prefix = '')
-    {
-        if (!empty($prefix)) {
-            $this->setVariable($prefix, $values);
-        }
-        else {
-            foreach ($values as $key => $value) {
-                $this->setVariable($key, $value);
-            }
-        }
-    }
-
-    public function getVariable($key, $default = null)
-    {
-        if (isset($this->variables[$key])) {
-            return $this->variables[$key];
-        }
-        return $default;
-    }
-
-    public function getVariables()
-    {
-        return $this->variables;
-    }
-
-    protected function setArguments(array $args = array())
-    {
-        $this->arguments = array_merge($this->arguments, $args);
-    }
-
-
-    /**
-     * @return mixed
-     */
-    public function getArgument($key, $default = null)
-    {
-        if (array_key_exists($key, $this->arguments)) {
-            return $this->arguments[$key];
-        }
-        return $default;
-    }
-
-    /**
-     * @return array
-     */
-    public function getArguments()
-    {
-        return $this->arguments;
+        return $revision;
     }
 }

--- a/src/Views/Doc.php
+++ b/src/Views/Doc.php
@@ -1,306 +1,87 @@
 <?php
+
 namespace MODXDocs\Views;
 
-use Knp\Menu\Matcher\Matcher;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use MODXDocs\Helpers\TocRenderer;
-use Webuni\CommonMark\TableExtension\TableExtension;
+use Psr\Container\ContainerInterface;
 use Slim\Exception\NotFoundException;
 use Slim\Http\Request;
 use Slim\Http\Response;
-use Spatie\YamlFrontMatter\YamlFrontMatter;
-use TOC\MarkupFixer;
-use TOC\TocGenerator;
 
-use MODXDocs\Helpers\LinkRenderer;
-
+use MODXDocs\Navigation\NavigationItemBuilder;
+use MODXDocs\Services\NavigationService;
+use MODXDocs\Services\RequestPathService;
+use MODXDocs\Services\DocumentService;
+use MODXDocs\Services\VersionsService;
+use MODXDocs\Services\FilePathService;
+use MODXDocs\Services\RequestAttributesService;
 
 class Doc extends Base
 {
-    protected $basePath;
-    protected $baseUri;
-    protected $file;
-    protected $version;
-    protected $language;
-    protected $docPath;
+    /** @var RequestPathService */
+    private $requestPathService;
 
-    public function setVersion($version)
+    /** @var FilePathService */
+    private $filePathService;
+
+    /** @var DocumentService */
+    private $documentService;
+
+    /** @var NavigationService */
+    private $navigationService;
+
+    /** @var VersionsService */
+    private $versionsService;
+
+    /** @var RequestAttributesService */
+    private $requestAttributesService;
+
+    public function __construct(ContainerInterface $container)
     {
-        $path = getenv('DOCS_DIRECTORY') . '/' . $version . '/';
-        if (!file_exists($path) || !is_dir($path)) {
-            throw new NotFoundException($this->request, $this->response);
-        }
-        $this->version = $version;
-        $this->setVariable('version', $version);
-        $this->setVariable('version_branch', $version === 'current' ? '2.x' : $version);
+        parent::__construct($container);
 
-        $this->basePath = $path;
-        $this->baseUri = '/' . $version;
+        $this->requestPathService = $this->container->get(RequestPathService::class);
+        $this->filePathService = $this->container->get(FilePathService::class);
+        $this->documentService = $this->container->get(DocumentService::class);
+        $this->navigationService = $this->container->get(NavigationService::class);
+        $this->versionsService = $this->container->get(VersionsService::class);
+        $this->requestAttributesService = $this->container->get(RequestAttributesService::class);
     }
 
-    public function setLanguage($language)
+    public function get(Request $request, Response $response)
     {
-        $path = $this->basePath . $language . '/';
-        if (!file_exists($path) || !is_dir($path)) {
-            throw new NotFoundException($this->request, $this->response);
-        }
-        $this->setVariable('language', $language);
-        $this->language = $language;
-        $this->basePath .= $language . '/';
-        $this->baseUri .= '/' . $language . '/';
-    }
-
-    public function setDocPath($path)
-    {
-        if (is_array($path)) {
-            $path = implode('/', $path);
-        }
-        $path = rtrim($path, '/');
-        $file = $path . '.md';
-        if (!file_exists($this->basePath . $file)) {
-            // See if we have an index file instead
-            $file = $path . '/index.md';
-
-            if (!file_exists($this->basePath . $file)) {
-                throw new NotFoundException($this->request, $this->response);
-            }
-        }
-        $this->docPath = $path;
-        $this->file = $file;
-        $this->setVariable('doc_path', $this->docPath);
-        $this->setVariable('file_path', $this->file);
-    }
-
-    public function initialize(Request $request, Response $response, array $args = array())
-    {
-        parent::initialize($request, $response, $args);
-        $this->setVersion($request->getAttribute('version'));
-        $this->setLanguage($request->getAttribute('language'));
-        $this->getTopNavigation();
-        $this->setDocPath($request->getAttribute('path'));
-        $this->getVersions();
-        $this->getNavigation();
-        return true;
-    }
-
-    public function home(Request $request, Response $response, array $args = array())
-    {
-        $request = $request
-            ->withAttribute('version', 'current')
-            ->withAttribute('language', 'en')
-            ->withAttribute('path', 'index');
-
-        return $this->get($request, $response, $args);
-    }
-
-    public function get(Request $request, Response $response, array $args = array())
-    {
-        $init = $this->initialize($request, $response, $args);
-        if ($init !== true) {
-            return $init;
+        if (!$this->requestPathService->isValidRequest($request) || !$this->filePathService->isValidRequest($request)) {
+            throw new NotFoundException($request, $response);
         }
 
-        $fileContents = file_get_contents($this->basePath . $this->file);
+        return $this->render($request, $response, 'documentation.twig', [
+            'page_title' => static::getPageTitle($request->getAttribute('path')),
 
-        // Parse the front matter and make it available as meta
-        $obj = YamlFrontMatter::parse($fileContents);
-        $data = $obj->matter();
-        $this->setVariable('meta', $data);
+            'meta' => $this->documentService->getMeta($request),
+            'parsed' => $this->documentService->getContent($request),
+            'toc' => $this->documentService->getTableOfContents($request),
 
+            'versions' => $this->versionsService->getVersions($request),
+            'nav' => $this->navigationService->getNavigation($request),
+            'current_nav_parent' => $this->navigationService->getNavParent(
+                (new NavigationItemBuilder())
+                    ->withCurrentFilePath($this->filePathService->getFilePath($request))
+                    ->withFilePath($this->requestPathService->getAbsoluteBaseFilePath($request))
+                    ->withPath($this->requestAttributesService->getPath($request))
+                    ->withVersion($this->requestAttributesService->getVersion($request))
+                    ->withLanguage($this->requestAttributesService->getLanguage($request))
+                    ->build()
+            ),
+        ]);
+    }
+
+    private static function getPageTitle($path)
+    {
         // Generate a page title crumbs kinda thing
-        $path = $request->getAttribute('path');
         $path = str_replace('-', ' ', $path);
         $path = explode('/', $path);
         $path = array_map('ucfirst', $path);
         $path = array_reverse($path);
-        $path = implode(' / ', $path);
-        $this->setVariable('page_title', $path);
 
-        // Process the content
-        $content = $obj->body();
-
-        // Grab the markdown
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new TableExtension());
-        $environment->addInlineRenderer('League\CommonMark\Inline\Element\Link',
-            new LinkRenderer($this->baseUri, $this->docPath)
-        );
-        $markdown = new CommonMarkConverter([
-            'html_input' => 'allow',
-        ], $environment);
-        $content = $markdown->convertToHtml($content);
-
-        $fixer = new MarkupFixer();
-        $content = $fixer->fix($content);
-        $this->setVariable('parsed', $content);
-
-        // Generate table of contents
-        $tocGenerator = new TocGenerator();
-        $renderer = new TocRenderer(new Matcher(), [
-            'currentClass'  => 'active',
-            'ancestorClass' => 'active_ancestor'
-        ], '/' . $request->getAttribute('version') . '/' . $request->getAttribute('language') . '/' . $this->docPath);
-        $toc = $tocGenerator->getHtmlMenu($content, 2, 6, $renderer);
-        $this->setVariable('toc', $toc);
-
-
-        return $this->render('documentation.twig');
-    }
-
-    public function getVersions()
-    {
-        $dir = new \DirectoryIterator(getenv('DOCS_DIRECTORY'));
-
-        $versions = [];
-        foreach ($dir as $fileinfo) {
-            if (!$fileinfo->isDir() || $fileinfo->isDot()) {
-                continue;
-            }
-
-            $file = $fileinfo->getPathname() . '/' . $this->language . '/' . $this->docPath;
-            $file = rtrim($file, '/');
-            if (file_exists($file . '.md') || file_exists($file . '/index.md')) {
-                $versions[] = [
-                    'title' => $fileinfo->getFilename(),
-                    'uri' => '/' . $fileinfo->getFilename() . '/' . $this->language . '/' . $this->docPath,
-                ];
-            }
-        }
-
-        $this->setVariable('versions', $versions);
-    }
-
-    public function getTopNavigation()
-    {
-        $topNav = $this->getNavigationForParent($this->basePath, 1, 1);
-        $this->setVariable('topnav', $topNav);
-    }
-
-    public function getNavigation()
-    {
-        // Make the navigation dependent on the current parent (administration, developing, xpdo, etc)
-        $docPath = explode('/', $this->docPath);
-        $menuPath = $this->basePath . $docPath[0];
-        if (file_exists($menuPath) && is_dir($menuPath)) {
-            if (file_exists($menuPath . '.md')) {
-                $item = $this->getNavItem(new \SplFileInfo($menuPath . '.md'), $docPath[0]);
-            }
-            else {
-                $item = $this->getNavItem(new \SplFileInfo($menuPath . '/index.md'), $docPath[0]);
-            }
-            $this->setVariable('current_nav_parent', $item);
-            $nav = $this->getNavigationForParent($menuPath);
-        }
-        // Fall back to listing 2 levels deep on home pages
-        else {
-            $nav = $this->getNavigationForParent($this->basePath, 1, 2);
-        }
-
-        $out = $this->container->view->fetch('partials/nav.twig', ['children' => $nav]);
-
-        $this->setVariable('nav', $out);
-    }
-
-    public function getNavigationForParent($path, $level = 1, $maxDepth = 10)
-    {
-        $nav = [];
-        try {
-            $dir = new \DirectoryIterator($path);
-        }
-        catch (\Exception $e) {
-            $this->logger->addError('Exception ' . get_class($e) . ' fetching navigation for ' . $path . ': ' . $e->getMessage());
-            return $nav;
-        }
-        foreach ($dir as $file) {
-            if ($file->isDot()) {
-                continue;
-            }
-
-            $filePath = $file->getPathname();
-            $filePath = strpos($filePath, '.md') !== false ? substr($filePath, 0, strpos($filePath, '.md')) : $filePath;
-            $relativeFilePath = str_replace($this->basePath, '', $filePath);
-
-            if ($file->isFile() && $file->getExtension() === 'md') {
-                if ($file->getFilename() === 'index.md') {
-                    continue;
-                }
-
-                $current = $this->getNavItem($file, $relativeFilePath);
-                $current['level'] = $level;
-
-                if ($level < $maxDepth && is_dir($filePath . '/')) {
-                    $current['classes'] .= ' has-children';
-                    $current['children'] = $this->getNavigationForParent($filePath . '/', $level + 1, $maxDepth);
-                }
-                $nav[] = $current;
-            }
-
-            // We handle directories slightly differently
-            elseif ($file->isDir()) {
-                if (file_exists($file->getPathname() . '/index.md')) {
-                    $current = $this->getNavItem(new \SplFileInfo($file->getPathname() . '/index.md'), $relativeFilePath);
-                    $current['level'] = $level;
-                    $current['classes'] .= ' has-children';
-                    if ($level < $maxDepth) {
-                        $current['children'] = $this->getNavigationForParent($file->getPathname(), $level + 1, $maxDepth);
-                    }
-                    $nav[] = $current;
-                }
-            }
-
-        }
-
-        usort($nav, function ($item, $item2) {
-            $so1 = array_key_exists('sortorder', $item) ? (int)$item['sortorder'] : null;
-            $so2 = array_key_exists('sortorder', $item2) ? (int)$item2['sortorder'] : null;
-            if ($so1 && !$so2) { return -1; }
-            if (!$so1 && $so2) { return 1; }
-            if (!$so1 && !$so2) { return strnatcmp($item['title'], $item2['title']); }
-            return $so1 - $so2;
-        });
-
-        return $nav;
-    }
-
-    private function getNavItem(\SplFileInfo $file, $relativeFilePath)
-    {
-        $fm = $this->getFrontmatter($file);
-        $current = [
-            'title' => $this->getTitle($file),
-            'uri' => $this->container->router->pathFor('documentation', [
-                'language' => $this->language,
-                'version' => $this->version,
-                'path' => $relativeFilePath,
-            ]),
-            'classes' => 'item',
-        ];
-        if (array_key_exists('sortorder', $fm)) {
-            $current['sortorder'] = (int)$fm['sortorder'];
-        }
-        if (strpos($this->file, $relativeFilePath) !== false) {
-            $current['classes'] .= ' active';
-        }
-
-        return $current;
-    }
-
-    private function getFrontmatter(\SplFileInfo $file) {
-        // Parse the front matter from the file
-        $fileContents = $file->isFile() ? file_get_contents($file->getPathname()) : false;
-        $obj = YamlFrontMatter::parse($fileContents);
-        return $obj->matter();
-    }
-
-    private function getTitle(\SplFileInfo $file)
-    {
-        $fm = $this->getFrontmatter($file);
-        $title = array_key_exists('title', $fm) ? $fm['title'] : '';
-        if (empty($title)) {
-            $name = $file->getFilename();
-            $title = strpos($name, '.md') !== false ? substr($name, 0, strpos($name, '.md')) : $name;
-            $title = implode(' ', explode('-', $title));
-        }
-        return $title;
+        return implode(' / ', $path);
     }
 }

--- a/src/Views/Doc.php
+++ b/src/Views/Doc.php
@@ -62,15 +62,7 @@ class Doc extends Base
 
             'versions' => $this->versionsService->getVersions($request),
             'nav' => $this->navigationService->getNavigation($request),
-            'current_nav_parent' => $this->navigationService->getNavParent(
-                (new NavigationItemBuilder())
-                    ->withCurrentFilePath($this->filePathService->getFilePath($request))
-                    ->withFilePath($this->requestPathService->getAbsoluteBaseFilePath($request))
-                    ->withPath($this->requestAttributesService->getPath($request))
-                    ->withVersion($this->requestAttributesService->getVersion($request))
-                    ->withLanguage($this->requestAttributesService->getLanguage($request))
-                    ->build()
-            ),
+            'current_nav_parent' => $this->navigationService->getNavParent($request),
         ]);
     }
 

--- a/templates/documentation.twig
+++ b/templates/documentation.twig
@@ -36,7 +36,7 @@
                     <p>
                         <small>
                             <em>
-                                {% if versions | length > 1 %}
+                                {% if versions %}
                                     Other versions:
                                     {% for version in versions %}
                                         <a href="{{ version.uri }}">{{ version.title }}</a>
@@ -44,10 +44,10 @@
                                     &mdash;
                                 {% endif %}
                                 Found a problem? Please
-                                <a href="https://github.com/modxorg/Docs/edit/{{ version_branch }}/{{ language }}/{{ file_path }}"
+                                <a href="https://github.com/modxorg/Docs/edit/{{ version_branch }}/{{ language }}/{{ path }}"
                                    target="_blank" rel="noopener">edit this page</a>
                                 or
-                                <a href="https://github.com/modxorg/Docs/issues/new?title=Issue+on+{{ file_path|url_encode }}&template=incorrect.md"
+                                <a href="https://github.com/modxorg/Docs/issues/new?title=Issue+on+{{ path|url_encode }}&template=incorrect.md"
                                    target="_blank" rel="noopener">report an issue</a>.
                             </em>
                         </small>


### PR DESCRIPTION
### What does it do?

It rewrites the majority of the backend code for the documentation application. 

See the entire source code in [OptimusCrime/DocsApp/rewrite-views-immutable](https://github.com/OptimusCrime/DocsApp/tree/rewrite-views-immutable).

### Why is it needed?

It makes the code much more manageable and readable. It takes advantage of the features in Slim, particularly dependency injection.

### Related issue(s)/PR(s)

None

### Detailed explanation

#### Utilizing dependency injection and services

Some DI was already used prior to my PR, but I have expanded upon this, and tried to separate logic where this was possible. 

It might be worth mentioning that the `Request` object is immutable, and you can not get this from the container. This is why the `$request` variable from the views are passed around to underlying services. Ideally, we could separate the services completely from the request (the web layer), but I was unable to do this in this iteration. I think it would be a great goal for the next one though. The main problem is that almost all logic is bound to the data found in the `$request` object, so we would have to box this in instead. 

Another problem is that the URLs and the actual file paths may differ with the concept of a "current" branch, as this is not actually present on the file system from a regular checkout. This causes some duplicated logic. 

#### Simpler views

The classes residing in `MODXDocs\Views`  are greatly simplified. The idea here is that the "web" layer, if you want to call it that, is not responsible for very much. It mainly passes data and information down to the services. Another goal was to make `MODXDocs\Views\NotFound` not extend `MODXDocs\Views\Doc` which it previously did. Constructing the top menu for 404-pages also turned out to be a bit of a challenge, and I am not 100% satisfied with the solution I came up with. Details about this under "Additional fixes and other things".

#### Services

Below are the services I have created, along with the responsibilities:

- **DocumentService**: Reads the actual markdown file and parses the content, along with TOC, meta etc.
- **FilePathService**: Takes a constructed URI `/2.x/en/getting-started` and resolves the logical file path for the markdown file. I _think_ this service can be removed some more logic may be moved into this one.
- **NavigationService**: Responsible for building the top menu and the left-side navigation. This service is _huge_. Some notes about this service below.
- **NotFoundService**: Tries to build a complete URI when a 404 is encountered, e.g. `4.x/en/` to `2.x/en`. `2.x/ennnnnn` to `2.x/en`.
- **RequestAttributesService**: Shortcut for reading the version, language and path attributes from the URI, with their default values in case these are not sat.
- **RequestPathService**: Provides full and base for URIs, and the full path for files. This might also be refactored in combination with FilePathService.
- **VersionService**: Fetches the other versions of the current document (if any).

The `NavigationService` was a bit of a pain in the ass, mainly because it does very much, and passes all sorts of information back and forth. Because `$request` is immutable, this means that we must pass this instance around everywhere. Additionally, we can not use the values directly available to us in `$request` for 404 pages, because we want to create the _most_ correct URI, and construct a top menu for that page instead. To fix this, I created a `NavigationItem` class, along with a builder (to keep things easier to handle), and pass this around instead of the actual `$request` instance.

#### Additional fixes and other things

- Some effort was done to remove all handling of relative URLs prior to my PR. I have removed _all_ functionality that supports relative paths, now everything is expected to begin with a leading slash.
- Versions of a document under the "current" branch is removed if you are on the same version branch (e.g. "Getting Started" will not have versions for both 2.x and current if you are on any of those, only 3.x)
- Versions now prefer "current" if the version branch for this is found.
- The old code depended on a symlink for the current branch. This is no longer necessary.

### Things that can be improved further

I have done a lot in this PR. Perhaps a bit too much, but it was difficult to touch some things, and leave other things when I made so big changes. Because of this, I would like to see this merged before another iteration is started, simply because the changeset will be too great if work is continued on this PR for too long.

Some things I would like to see improved in the future:

- Split `NavigationService`, this service is too big and does too much.
- Find a better way to handle information passed from the views to the services, perhaps creating a simple class that takes version, language and path?
- Avoid repeating the same pieces of code more than once, this includes constructing the file path for the documents.
- Migrate or move some of the logic from `RequestPathService` into `FilePathService` so they each have their separate responsibilities. Now `RequestPathService` also resolves some file paths, which is not good.

