### PR TITLE
Removes an alert

### DIFF
--- a/public/template/src/js/components/search.js
+++ b/public/template/src/js/components/search.js
@@ -117,7 +117,6 @@ class Search {
             })
             .catch(function(error) {
                 console.error(error);
-                alert(error.message);
             })
             .finally(function() {
                 targetDom.classList.remove('l-live-search__container--loading');


### PR DESCRIPTION
### What does it do?

Removes an alert dialog that appears when an HTTP error occurs during a live search request

### Why is it needed?

Users should not see an alert. They are intrusive and are not very useful for users. 

### Related issue(s)/PR(s)