### PR TITLE
Make the footer "sticky"

### DIFF
--- a/public/template/src/scss/_layout.scss
+++ b/public/template/src/scss/_layout.scss
@@ -6,6 +6,10 @@ html, body {
 }
 
 .l-app {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+
     padding-top: $header-height;
     background: map-get($colors, 'body-bg');
     //filter: invert(100%);
@@ -91,6 +95,8 @@ html, body {
 .l-main {
     position: relative;
     margin: $main-margin-top rem(20) $global-margin;
+
+    flex: 1;
 
     @include breakpoint(medium) {
         margin: $main-margin-top rem(50) $global-margin rem(75);


### PR DESCRIPTION
### What does it do?

Expand the height of the main content to take up all available space

### Why is it needed?

To "press" the footer to the bottom even when the main content isn't long enough.

### Related issue(s)/PR(s)

Fixes #53 
