### PR TITLE
Add very simple browser-language based prompt on the homepage

### DIFF
--- a/templates/documentation.twig
+++ b/templates/documentation.twig
@@ -62,6 +62,22 @@
                 </small>
             </p>
 
+            {% if 'en' in suggested_languages %}
+            <div class="c-callout c-callout--info">
+                Hello! <a href="{{ path_for('documentation', {version: version, language: 'en', path: 'index'}) }}">The MODX documentation is also available in English</a>.
+            </div>
+            {% endif %}
+            {% if 'nl' in suggested_languages %}
+            <div class="c-callout c-callout--info">
+                Hoi! <a href="{{ path_for('documentation', {version: version, language: 'nl', path: 'index'}) }}">De MODX documentatie is ook (deels) in het Nederlandstalig beschikbaar</a>.
+            </div>
+            {% endif %}
+            {% if 'ru' in suggested_languages %}
+            <div class="c-callout c-callout--info">
+                Здравствуй! <a href="{{ path_for('documentation', {version: version, language: 'ru', path: 'index'}) }}">Документация MODX также доступна на русском языке</a>.
+            </div>
+            {% endif %}
+
             {% if meta.suggest_delete %}
                 <div class="c-callout c-callout--warning">
                     This page is marked as a candidate to be deleted: {{ meta.suggest_delete }}


### PR DESCRIPTION
Only on the homepage, prompts people to find their local translation.

![Schermafbeelding 2019-12-12 om 02 08 26](https://user-images.githubusercontent.com/312944/70673853-52e19e00-1c84-11ea-9d58-b62232a433b4.jpg)

Only shows languages indicated as supported by the browser, of course, and the current language (i.e. english on /current/en) is ignored as well.

Used Google Translate for the Russian - @Ibochkarev can you check/improve that for me? Also asked in slack but it's the middle of the night in Russia so don't expect a reply right away: https://modxcommunity.slack.com/archives/C042VL159/p1576112337001100