### PR TITLE
Update Tree.php

### DIFF
--- a/src/Navigation/Tree.php
+++ b/src/Navigation/Tree.php
@@ -61,7 +61,7 @@ class Tree {
             }
 
 
-            $filePath = $file->getPathname();
+            $filePath = str_replace('\\','/',$file->getPathname());
             $relativeFilePath = str_replace($root, '', $filePath);
             $relativeUrl = strpos($relativeFilePath, '.md') !== false ? substr($relativeFilePath, 0, strpos($relativeFilePath, '.md')) : $relativeFilePath;
             $relativeUrl = strpos($relativeUrl, $directoryPrefix) === 0 ? substr($relativeUrl, strlen($directoryPrefix)) : $relativeUrl;


### PR DESCRIPTION
Fix navigation doesn't work on Windows

### What does it do?

replaces backslashes with slashes on filePath

### Why is it needed?

The navigation ends up with urls like

http://docs.modxdocs.site/current/en/2.x/en/getting-started/installation

while it should be

http://docs.modxdocs.site/current/en/getting-started/installation

because on windows $file->getPathname() returns a path like

/laragon/www/modxdocs/DocsApp/docs/2.x/en\getting-started\installation

and the directoryPrefix isn't replaced correctly

### Related issue(s)/PR(s)

If there's a related issue, please add `Fixes #<issue number>`.
